### PR TITLE
Update Program.cs: Update Command Line Description

### DIFF
--- a/src/Applications/ToCBS/Program.cs
+++ b/src/Applications/ToCBS/Program.cs
@@ -18,8 +18,8 @@ Version: 1.0.2.0
                 Console.WriteLine("You need to pass at least 2 parameters:");
                 Console.WriteLine(@"	<Path to MainOS/Data/EFIESP> <Output folder CBSs>");
                 Console.WriteLine("Examples:");
-                Console.WriteLine(@"	 ""D:\"" ""C:\OutputCabs\""");
-                Console.WriteLine(@"	 ""D:\"" ""E:\"" ""F:\"" ""C:\OutputCabs\""");
+                Console.WriteLine(@"	 D:\ ""C:\OutputCabs\""");
+                Console.WriteLine(@"	 D:\ E:\ F:\ ""C:\OutputCabs\""");
                 return;
             }
 


### PR DESCRIPTION
Trying to start the program with the parameters given in the original description will result in args.Length==1. Removing the first set of quotes does not affect the parameter passing and can solve this problem.