### PR TITLE
Update BuildMetadataHandler.cs: modify the order of string replacemen…

### DIFF
--- a/src/MobilePackageGen.Common/BuildMetadataHandler.cs
+++ b/src/MobilePackageGen.Common/BuildMetadataHandler.cs
@@ -327,14 +327,6 @@ namespace MobilePackageGen
 
         private static string ReformatDestinationPath(string DestinationPath)
         {
-            if (DestinationPath[1] == ':')
-            {
-                string DriveLetter = DestinationPath[0].ToString().ToUpper();
-                string DriveLetterLessPath = DestinationPath[3..];
-
-                DestinationPath = Path.Combine($"Drive{DriveLetter}", DriveLetterLessPath);
-            }
-
             if (DestinationPath.StartsWith(@"\\?\") && DestinationPath[5] == ':')
             {
                 string UNCLessPath = DestinationPath[4..];
@@ -358,6 +350,14 @@ namespace MobilePackageGen
                 DestinationPath = Path.Combine($"UNC", UNCLessPath);
             }
 
+            if (DestinationPath[1] == ':')
+            {
+                string DriveLetter = DestinationPath[0].ToString().ToUpper();
+                string DriveLetterLessPath = DestinationPath[3..];
+
+                DestinationPath = Path.Combine($"Drive{DriveLetter}", DriveLetterLessPath);
+            }
+            
             return DestinationPath;
         }
 


### PR DESCRIPTION
this pr fixed the creation problem of paths starting with `\\?\U:\SharedData\DuShared\PackagesToInstall\` since commit 5c1da356f7bdadbf8202e777077ea7e8f34325f3