### PR TITLE
Update BuildMetadataHandler.cs: Corrected the logic for some package events where IsRemoval=true.

### DIFF
--- a/src/MobilePackageGen.Common/BuildMetadataHandler.cs
+++ b/src/MobilePackageGen.Common/BuildMetadataHandler.cs
@@ -408,12 +408,12 @@ namespace MobilePackageGen
                 {
                     foreach (UpdateHistory.Package Package in UpdateEvent.UpdateOSOutput.Packages.Package)
                     {
-                        if (Package.PackageFile.EndsWith(".mum", StringComparison.InvariantCultureIgnoreCase))
+                        if (Package.PackageIdentity == null || Package.PackageFile == null)
                         {
                             continue;
                         }
-
-                        if (Package.PackageIdentity == null)
+                        
+                        if (Package.PackageFile.EndsWith(".mum", StringComparison.InvariantCultureIgnoreCase))
                         {
                             continue;
                         }
@@ -468,6 +468,11 @@ namespace MobilePackageGen
                 {
                     foreach (UpdateHistory.Package Package in UpdateEvent.UpdateOSOutput.Packages.Package)
                     {
+                        if (Package.PackageFile == null)
+                        {
+                            continue;
+                        }
+                        
                         if (Package.PackageFile.EndsWith(".mum", StringComparison.InvariantCultureIgnoreCase))
                         {
                             continue;


### PR DESCRIPTION
Corrected the logic for some package events where IsRemoval=true.

In this case, PackageFile might be null (this happened on my old 20279 installation).